### PR TITLE
Replace explicit type collections with boolean accessors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+      
+jobs:
+  build:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: swift test

--- a/Sources/UniformTypeIdentifier/Collections.swift
+++ b/Sources/UniformTypeIdentifier/Collections.swift
@@ -1,237 +1,77 @@
 import Foundation
 
 extension UniformTypeIdentifier {
-    /// `Set` of `UniformTypeIdentifier`s including user-generated documents, media, and other files.
-    ///
-    /// Does not include directories, aliases, or bundles.
-    public static var documentTypes: Set<UniformTypeIdentifier> {
-        [
-            .item,
-            .content,
-            .compositeContent,
-            .message,
-            .contact,
-            .data,
-            .url,
-            .fileURL,
-            .text,
-            .plainText,
-            .utf8PlainText,
-            .utf16ExternalPlainText,
-            .utf16PlainText,
-            .delimitedText,
-            .commaSeparatedText,
-            .tabSeparatedText,
-            .utf8TabSeparatedText,
-            .rtf,
-            .html,
-            .xml,
-            .sourceCode,
-            .assemblyLanguageSource,
-            .cSource,
-            .objectiveCSource,
-            .swiftSource,
-            .cPlusPlusSource,
-            .objectiveCPlusPlusSource,
-            .cHeader,
-            .cPlusPlusHeader,
-            .javaSource,
-            .script,
-            .appleScript,
-            .osaScript,
-            .osaScriptBundle,
-            .javaScript,
-            .shellScript,
-            .perlScript,
-            .pythonScript,
-            .rubyScript,
-            .phpScript,
-            .json,
-            .propertyList,
-            .xmlPropertyList,
-            .binaryPropertyList,
-            .pdf,
-            .rtfd,
-            .flatRTFD,
-            .txnTextAndMultimediaData,
-            .webArchive,
-            .image,
-            .jpeg,
-            .jpeg2000,
-            .tiff,
-            .pict,
-            .gif,
-            .png,
-            .quickTimeImage,
-            .appleICNS,
-            .bmp,
-            .ico,
-            .rawImage,
-            .scalableVectorGraphics,
-            .livePhoto,
-            .audiovisualContent,
-            .movie,
-            .video,
-            .audio,
-            .quickTimeMovie,
-            .mpeg,
-            .mpeg2Video,
-            .mpeg2TransportStream,
-            .mp3,
-            .mpeg4,
-            .mpeg4Audio,
-            .appleProtectedMPEG4Audio,
-            .appleProtectedMPEG4Video,
-            .aviMovie,
-            .audioInterchangeFileFormat,
-            .waveformAudio,
-            .midiAudio,
-            .playlist,
-            .m3uPlaylist,
-            .javaClass,
-            .javaArchive,
-            .gnuZipArchive,
-            .bzip2Archive,
-            .zipArchive,
-            .spreadsheet,
-            .presentation,
-            .database,
-            .vCard,
-            .toDoItem,
-            .calendarEvent,
-            .emailMessage,
-            .internetLocation,
-            .inkText,
-            .font,
-            .bookmark,
-            ._3dContent,
-            .pkcs12,
-            .x509Certificate,
-            .electronicPublication,
-            .log,
-            .postscript,
-            .encapsulatedPostscript,
-            .photoshopImage,
-            .aiImage,
-            .wordDocument,
-            .excelSpreadsheet,
-            .powerpointPresentation,
-            .advancedSystems,
-            .windowsMediaWM,
-            .windowsMediaWMV,
-            .windowsMediaWMP,
-            .windowsMediaWMA,
-            .advancedStreamRedirector,
-            .windowsMediaWMX,
-            .windowsMediaWVX,
-            .windowsMediaWAX,
-            .keynotePresentation,
-            .keynoteTheme,
-            .tgaImage,
-            .sgiImage,
-            .openEXRImage,
-            .flashPixImage,
-            .jfxFax,
-            .efxFax,
-            .sd2Audio,
-            .realMedia,
-            .realMediaAudio,
-            .realSMIL,
-            .stuffitArchive,
-            .wordDocumentXML,
-            .excelSpreadsheetXML,
-            .powerpointPresentationXML,
-        ]
+    /// `UniformTypeIdentifier`s including user-generated documents, media, and other files.
+    public var isDocument: Bool {
+        if isImage || isVideo || isAudio || conforms(to: .content) {
+            return true
+        } else {
+            switch self {
+            case .osaScriptBundle,
+                 .propertyList,
+                 .xmlPropertyList,
+                 .binaryPropertyList,
+                 .playlist,
+                 .javaClass,
+                 .javaArchive,
+                 .gnuZipArchive,
+                 .zipArchive,
+                 .bzip2Archive,
+                 .database,
+                 .toDoItem,
+                 .calendarEvent,
+                 .emailMessage,
+                 .font,
+                 .pkcs12,
+                 .x509Certificate,
+                 .log,
+                 .efxFax,
+                 .stuffitArchive:
+                return true
+                
+            default:
+                return false
+            }
+        }
     }
-}
 
-extension UniformTypeIdentifier {
     /// `Set` of `UniformTypeIdentifier`s including image types.
-    public static var imageTypes: Set<UniformTypeIdentifier> {
-        [
-            .image,
-            .jpeg,
-            .jpeg2000,
-            .tiff,
-            .pict,
-            .gif,
-            .png,
-            .quickTimeImage,
-            .appleICNS,
-            .bmp,
-            .ico,
-            .rawImage,
-            .scalableVectorGraphics,
-            .livePhoto,
-            .photoshopImage,
-            .aiImage,
-            .tgaImage,
-            .sgiImage,
-            .openEXRImage,
-            .flashPixImage,
-            .apng,
-            .avif,
-            .webp,
-        ]
+    public var isImage: Bool {
+        if conforms(to: .image) {
+            return true
+        } else {
+            switch self {
+            case .livePhoto, .flashPixImage, .apng, .avif:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
-    /// `Set` of `UniformTypeIdentifier`s including video and video collection types.
-    public static var videoTypes: Set<UniformTypeIdentifier> {
-        [
-            .audiovisualContent,
-            .movie,
-            .video,
-            .quickTimeMovie,
-            .mpeg,
-            .mpeg2Video,
-            .mpeg2TransportStream,
-            .mpeg4,
-            .appleProtectedMPEG4Video,
-            .aviMovie,
-            .windowsMediaWM,
-            .windowsMediaWMV,
-            .windowsMediaWMP,
-            .windowsMediaWMX,
-            .windowsMediaWVX,
-            .realMedia,
-            .realSMIL,
-            .webmVideo,
-            .oggVideo,
-            .oggApplication,
-        ]
+    public var isVideo: Bool {
+        if conforms(to: .audiovisualContent) {
+            return true
+        } else {
+            switch self {
+            case .webmVideo, .oggVideo:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
-    /// `Set` of `UniformTypeIdentifier`s including audio and audio collection types.
-    public static var audioTypes: Set<UniformTypeIdentifier> {
-        [
-            .audio,
-            .mp3,
-            .mpeg4Audio,
-            .appleProtectedMPEG4Video,
-            .audioInterchangeFileFormat,
-            .waveformAudio,
-            .midiAudio,
-            .playlist,
-            .m3uPlaylist,
-            .windowsMediaWAX,
-            .sd2Audio,
-            .realMediaAudio,
-            .webmAudio,
-            .oggAudio,
-        ]
-    }
-}
-
-extension UniformTypeIdentifier {
-    /// `Set` of `UniformTypeIdentifier`s including folders and bundles.
-    public static var directoryTypes: Set<UniformTypeIdentifier> {
-        [
-            .directory,
-            .folder,
-            .volume,
-            .package,
-            .bundle,
-            .applicationBundle,
-        ]
+    public var isAudio: Bool {
+        if conforms(to: .audio) {
+            return true
+        } else {
+            switch self {
+            case .webmAudio, .oggAudio:
+                return true
+            default:
+                return false
+            }
+        }
     }
 }

--- a/Sources/UniformTypeIdentifier/Collections.swift
+++ b/Sources/UniformTypeIdentifier/Collections.swift
@@ -26,7 +26,8 @@ extension UniformTypeIdentifier {
                  .x509Certificate,
                  .log,
                  .efxFax,
-                 .stuffitArchive:
+                 .stuffitArchive,
+                 .wordDocument:
                 return true
                 
             default:

--- a/Sources/UniformTypeIdentifier/PublicTypes.swift
+++ b/Sources/UniformTypeIdentifier/PublicTypes.swift
@@ -67,6 +67,8 @@ extension UniformTypeIdentifier {
     public static let txnTextAndMultimediaData = UniformTypeIdentifier(rawValue: kUTTypeTXNTextAndMultimediaData as String)
     public static let webArchive = UniformTypeIdentifier(rawValue: kUTTypeWebArchive as String)
     public static let image = UniformTypeIdentifier(rawValue: kUTTypeImage as String)
+    public static let heifStandard = UniformTypeIdentifier(rawValue: "public.heif-standard")
+    public static let heif = UniformTypeIdentifier(rawValue: "public.heif")
     public static let jpeg = UniformTypeIdentifier(rawValue: kUTTypeJPEG as String)
     public static let jpeg2000 = UniformTypeIdentifier(rawValue: kUTTypeJPEG2000 as String)
     public static let tiff = UniformTypeIdentifier(rawValue: kUTTypeTIFF as String)
@@ -79,6 +81,7 @@ extension UniformTypeIdentifier {
     public static let ico = UniformTypeIdentifier(rawValue: kUTTypeICO as String)
     public static let rawImage = UniformTypeIdentifier(rawValue: kUTTypeRawImage as String)
     public static let scalableVectorGraphics = UniformTypeIdentifier(rawValue: kUTTypeScalableVectorGraphics as String)
+    public static let heic = UniformTypeIdentifier(rawValue: "public.heic")
     public static let livePhoto = UniformTypeIdentifier(rawValue: kUTTypeLivePhoto as String)
     public static let audiovisualContent = UniformTypeIdentifier(rawValue: kUTTypeAudiovisualContent as String)
     public static let movie = UniformTypeIdentifier(rawValue: kUTTypeMovie as String)
@@ -166,14 +169,13 @@ extension UniformTypeIdentifier {
     public static let sd2Audio = UniformTypeIdentifier(rawValue: "com.digidesign.sd2-audio")
     public static let realMedia = UniformTypeIdentifier(rawValue: "com.real.realmedia")
     public static let realMediaAudio = UniformTypeIdentifier(rawValue: "com.real.realaudio")
-    public static let realSMIL = UniformTypeIdentifier(rawValue: "com.real.smil")
     public static let stuffitArchive = UniformTypeIdentifier(rawValue: "com.allume.stuffit-archive")
 }
 
 extension UniformTypeIdentifier {
     public static let apng = UniformTypeIdentifier(mimeType: "image/apng")!
     public static let avif = UniformTypeIdentifier(mimeType: "image/avif")!
-    public static let webp = UniformTypeIdentifier(mimeType: "image/webp")!
+    public static let webp = UniformTypeIdentifier(rawValue: "org.webmproject.webp")
     public static let flash = UniformTypeIdentifier(mimeType: "video/x-flv")!
     public static let webmVideo = UniformTypeIdentifier(mimeType: "video/webm")!
     public static let _3gp = UniformTypeIdentifier(mimeType: "video/3gpp")!

--- a/Tests/UniformTypeIdentifierTests/CollectionsTests.swift
+++ b/Tests/UniformTypeIdentifierTests/CollectionsTests.swift
@@ -186,7 +186,7 @@ private extension CollectionsTests {
             .avif,
         ]
 
-        if #available(iOS 14, macOS 10.16, *) {
+        if #available(iOS 14, macOS 11.0, *) {
             types.append(.webp)
         }
 

--- a/Tests/UniformTypeIdentifierTests/CollectionsTests.swift
+++ b/Tests/UniformTypeIdentifierTests/CollectionsTests.swift
@@ -186,7 +186,7 @@ private extension CollectionsTests {
             .avif,
         ]
 
-        if #available(iOS 14, *) {
+        if #available(iOS 14, macOS 10.16, *) {
             types.append(.webp)
         }
 

--- a/Tests/UniformTypeIdentifierTests/CollectionsTests.swift
+++ b/Tests/UniformTypeIdentifierTests/CollectionsTests.swift
@@ -2,18 +2,238 @@ import XCTest
 import UniformTypeIdentifier
 
 final class CollectionsTests: XCTestCase {
-    func testImageTypes() throws {
-        let imageTypes = UniformTypeIdentifier.imageTypes
-        XCTAssertEqual(23, imageTypes.count)
+    func testIsDocument() throws {
+        Self.documentTypes.forEach { (type) in
+            XCTAssertTrue(type.isDocument, "\(type.rawValue) is not a document")
+        }
+
+        XCTAssertFalse(UniformTypeIdentifier.directory.isDocument)
+        XCTAssertFalse(UniformTypeIdentifier.folder.isDocument)
+        XCTAssertFalse(UniformTypeIdentifier.symLink.isDocument)
     }
 
-    func testVideoTypes() throws {
-        let videoTypes = UniformTypeIdentifier.videoTypes
-        XCTAssertEqual(20, videoTypes.count)
+    func testIsImage() throws {
+        Self.imageTypes.forEach { (type) in
+            XCTAssertTrue(type.isImage, "\(type.rawValue) is not an image")
+        }
     }
 
-    func testAudioTypes() throws {
-        let audioTypes = UniformTypeIdentifier.audioTypes
-        XCTAssertEqual(14, audioTypes.count)
+    func testIsVideo() throws {
+        Self.videoTypes.forEach { (type) in
+            XCTAssertTrue(type.isVideo, "\(type.rawValue) is not a video")
+        }
     }
+
+    func testIsAudio() throws {
+        Self.audioTypes.forEach { (type) in
+            XCTAssertTrue(type.isAudio, "\(type.rawValue) is not audio")
+        }
+    }
+}
+
+private extension CollectionsTests {
+    static let documentTypes: [UniformTypeIdentifier] = [
+        .content,
+        .compositeContent,
+        .text,
+        .plainText,
+        .utf8PlainText,
+        .utf16ExternalPlainText,
+        .utf16PlainText,
+        .delimitedText,
+        .commaSeparatedText,
+        .tabSeparatedText,
+        .utf8TabSeparatedText,
+        .rtf,
+        .html,
+        .xml,
+        .sourceCode,
+        .assemblyLanguageSource,
+        .cSource,
+        .objectiveCSource,
+        .swiftSource,
+        .cPlusPlusSource,
+        .objectiveCPlusPlusSource,
+        .cHeader,
+        .cPlusPlusHeader,
+        .javaSource,
+        .script,
+        .appleScript,
+        .osaScript,
+        .osaScriptBundle,
+        .javaScript,
+        .shellScript,
+        .perlScript,
+        .pythonScript,
+        .rubyScript,
+        .phpScript,
+        .json,
+        .propertyList,
+        .xmlPropertyList,
+        .binaryPropertyList,
+        .pdf,
+        .rtfd,
+        .flatRTFD,
+        .txnTextAndMultimediaData,
+        .webArchive,
+        .image,
+        .jpeg,
+        .jpeg2000,
+        .tiff,
+        .pict,
+        .gif,
+        .png,
+        .quickTimeImage,
+        .appleICNS,
+        .bmp,
+        .ico,
+        .rawImage,
+        .scalableVectorGraphics,
+        .livePhoto,
+        .audiovisualContent,
+        .movie,
+        .video,
+        .audio,
+        .quickTimeMovie,
+        .mpeg,
+        .mpeg2Video,
+        .mpeg2TransportStream,
+        .mp3,
+        .mpeg4,
+        .mpeg4Audio,
+        .appleProtectedMPEG4Audio,
+        .appleProtectedMPEG4Video,
+        .aviMovie,
+        .audioInterchangeFileFormat,
+        .waveformAudio,
+        .midiAudio,
+        .playlist,
+        .m3uPlaylist,
+        .javaClass,
+        .javaArchive,
+        .gnuZipArchive,
+        .bzip2Archive,
+        .zipArchive,
+        .spreadsheet,
+        .presentation,
+        .database,
+        .vCard,
+        .toDoItem,
+        .calendarEvent,
+        .emailMessage,
+        .font,
+        ._3dContent,
+        .pkcs12,
+        .x509Certificate,
+        .electronicPublication,
+        .log,
+        .postscript,
+        .encapsulatedPostscript,
+        .photoshopImage,
+        .aiImage,
+        .wordDocument,
+        .excelSpreadsheet,
+        .powerpointPresentation,
+        .advancedSystems,
+        .windowsMediaWM,
+        .windowsMediaWMV,
+        .windowsMediaWMP,
+        .windowsMediaWMA,
+        .advancedStreamRedirector,
+        .windowsMediaWMX,
+        .windowsMediaWVX,
+        .windowsMediaWAX,
+        .keynotePresentation,
+        .keynoteTheme,
+        .tgaImage,
+        .sgiImage,
+        .openEXRImage,
+        .flashPixImage,
+        .jfxFax,
+        .efxFax,
+        .sd2Audio,
+        .realMedia,
+        .realMediaAudio,
+        .stuffitArchive,
+        .wordDocumentXML,
+        .excelSpreadsheetXML,
+        .powerpointPresentationXML,
+    ]
+
+    static let imageTypes: [UniformTypeIdentifier] = {
+        var types: [UniformTypeIdentifier] = [
+            .image,
+            .jpeg,
+            .jpeg2000,
+            .tiff,
+            .pict,
+            .gif,
+            .png,
+            .quickTimeImage,
+            .appleICNS,
+            .bmp,
+            .ico,
+            .rawImage,
+            .scalableVectorGraphics,
+            .livePhoto,
+            .photoshopImage,
+            .aiImage,
+            .tgaImage,
+            .sgiImage,
+            .openEXRImage,
+            .flashPixImage,
+            .apng,
+            .avif,
+        ]
+
+        if #available(iOS 14, *) {
+            types.append(.webp)
+        }
+
+        return types
+    }()
+
+    static let videoTypes: [UniformTypeIdentifier] = [
+        .audiovisualContent,
+        .movie,
+        .video,
+        .quickTimeMovie,
+        .mpeg,
+        .mpeg2Video,
+        .mpeg2TransportStream,
+        .mpeg4,
+        .appleProtectedMPEG4Video,
+        .aviMovie,
+        .windowsMediaWM,
+        .windowsMediaWMV,
+        .windowsMediaWMP,
+        .windowsMediaWMX,
+        .windowsMediaWVX,
+        .realMedia,
+        .webmVideo,
+        .oggVideo,
+    ]
+    
+    static let audioTypes: [UniformTypeIdentifier] = [
+        .audio,
+        .mp3,
+        .mpeg4Audio,
+        .audioInterchangeFileFormat,
+        .waveformAudio,
+        .midiAudio,
+        .windowsMediaWAX,
+        .sd2Audio,
+        .realMediaAudio,
+        .webmAudio,
+        .oggAudio,
+    ]
+
+    static var directoryTypes: [UniformTypeIdentifier] = [
+        .directory,
+        .folder,
+        .volume,
+        .package,
+        .bundle,
+        .applicationBundle,
+    ]
 }

--- a/Tests/UniformTypeIdentifierTests/UniformTypeIdentifierTests.swift
+++ b/Tests/UniformTypeIdentifierTests/UniformTypeIdentifierTests.swift
@@ -137,6 +137,37 @@ final class UniformTypeIdentifierTests: XCTestCase {
         XCTAssertNil(UniformTypeIdentifier.internetLocation.mimeType)
     }
 
+    func testAdditionalTypes() throws {
+        // webp
+        let webp = UniformTypeIdentifier.webp
+        XCTAssertEqual("org.webmproject.webp", webp.rawValue)
+        if #available(iOS 14, *) {
+            XCTAssertEqual("image/webp", webp.mimeType)
+            XCTAssertEqual(["webp"], webp.allFileExtensions)
+            XCTAssertTrue(webp.conforms(to: .image))
+        }
+
+        // heif
+        let heif = UniformTypeIdentifier.heif
+        XCTAssertEqual("public.heif", heif.rawValue)
+        XCTAssertEqual("image/heif", heif.mimeType)
+        if #available(iOS 14, *) {
+            XCTAssertEqual(["heif", "hif"], heif.allFileExtensions)
+        } else {
+            XCTAssertEqual(["heif"], heif.allFileExtensions)
+        }
+        XCTAssertTrue(heif.conforms(to: .heifStandard))
+        XCTAssertTrue(heif.conforms(to: .image))
+
+        // heic
+        let heic = UniformTypeIdentifier.heic
+        XCTAssertEqual("public.heic", heic.rawValue)
+        XCTAssertEqual("image/heic", heic.mimeType)
+        XCTAssertEqual(["heic"], heic.allFileExtensions)
+        XCTAssertTrue(heic.conforms(to: .heifStandard))
+        XCTAssertTrue(heic.conforms(to: .image))
+    }
+
     func testAllMIMETypes() throws {
         XCTAssertEqual(Set(["text/rtf"]), Set(UniformTypeIdentifier.rtf.allMIMETypes))
         XCTAssertEqual(Set(["text/html"]), Set(UniformTypeIdentifier.html.allMIMETypes))

--- a/Tests/UniformTypeIdentifierTests/UniformTypeIdentifierTests.swift
+++ b/Tests/UniformTypeIdentifierTests/UniformTypeIdentifierTests.swift
@@ -141,7 +141,7 @@ final class UniformTypeIdentifierTests: XCTestCase {
         // webp
         let webp = UniformTypeIdentifier.webp
         XCTAssertEqual("org.webmproject.webp", webp.rawValue)
-        if #available(iOS 14, *) {
+        if #available(iOS 14, macOS 10.16, *) {
             XCTAssertEqual("image/webp", webp.mimeType)
             XCTAssertEqual(["webp"], webp.allFileExtensions)
             XCTAssertTrue(webp.conforms(to: .image))
@@ -151,7 +151,7 @@ final class UniformTypeIdentifierTests: XCTestCase {
         let heif = UniformTypeIdentifier.heif
         XCTAssertEqual("public.heif", heif.rawValue)
         XCTAssertEqual("image/heif", heif.mimeType)
-        if #available(iOS 14, *) {
+        if #available(iOS 14, macOS 10.16, *) {
             XCTAssertEqual(["heif", "hif"], heif.allFileExtensions)
         } else {
             XCTAssertEqual(["heif"], heif.allFileExtensions)

--- a/Tests/UniformTypeIdentifierTests/UniformTypeIdentifierTests.swift
+++ b/Tests/UniformTypeIdentifierTests/UniformTypeIdentifierTests.swift
@@ -141,7 +141,7 @@ final class UniformTypeIdentifierTests: XCTestCase {
         // webp
         let webp = UniformTypeIdentifier.webp
         XCTAssertEqual("org.webmproject.webp", webp.rawValue)
-        if #available(iOS 14, macOS 10.16, *) {
+        if #available(iOS 14, macOS 11.0, *) {
             XCTAssertEqual("image/webp", webp.mimeType)
             XCTAssertEqual(["webp"], webp.allFileExtensions)
             XCTAssertTrue(webp.conforms(to: .image))
@@ -151,7 +151,7 @@ final class UniformTypeIdentifierTests: XCTestCase {
         let heif = UniformTypeIdentifier.heif
         XCTAssertEqual("public.heif", heif.rawValue)
         XCTAssertEqual("image/heif", heif.mimeType)
-        if #available(iOS 14, macOS 10.16, *) {
+        if #available(iOS 14, macOS 11.0, *) {
             XCTAssertEqual(["heif", "hif"], heif.allFileExtensions)
         } else {
             XCTAssertEqual(["heif"], heif.allFileExtensions)


### PR DESCRIPTION
Add `isDocument`, `isImage`, `isVideo`, and `isAudio`.